### PR TITLE
[Bug-Fix] When shipping address is null (e.g. virtual products) there is an error

### DIFF
--- a/app/code/community/PH2M/Gdpr/Model/Customer/Data/Remove.php
+++ b/app/code/community/PH2M/Gdpr/Model/Customer/Data/Remove.php
@@ -267,6 +267,9 @@ class PH2M_Gdpr_Model_Customer_Data_Remove extends Mage_Core_Model_Abstract impl
      */
     protected function anonymizeSaleAddress($address)
     {
+        if(empty($address)){
+            return;
+        }
         $helper = Mage::helper('phgdpr');
         $address->setFirstname($helper->getRandom());
         $address->setMiddlename($helper->getRandom());


### PR DESCRIPTION
I've encountered this on our website when trying to anonymize a user's existing orders. The products are virtual and the user isn't required to fill in his shipping details, therefore the shipping address in this case is null and not an Id. Therefore `$order->getShippingAddress()` will return false and there is no handling for this use case. 

This pull request is a suggestion but maybe you want to implement a more robust check in this scenario. 