### PR TITLE
Enable label translation

### DIFF
--- a/app/design/frontend/base/default/layout/ph/gdpr.xml
+++ b/app/design/frontend/base/default/layout/ph/gdpr.xml
@@ -60,12 +60,12 @@
     </default>
     <customer_account>
         <reference name="customer_account_navigation">
-            <action method="addLink" translate="label" ifconfig="phgdpr/customer_data_remove/enable" condition="1">
+            <action method="addLink" translate="label" ifconfig="phgdpr/customer_data_remove/enable" condition="1" translate="label">
                 <name>delete</name>
                 <path>phgdpr/customer/deleteconfirmation</path>
                 <label>Delete my account</label>
             </action>
-            <action method="addLink" translate="label" ifconfig="phgdpr/customer_data_download/enable" condition="1">
+            <action method="addLink" translate="label" ifconfig="phgdpr/customer_data_download/enable" condition="1" translate="label">
                 <name>download</name>
                 <path>phgdpr/customer/downloadview</path>
                 <label>Download my account data</label>


### PR DESCRIPTION
Hi,

I installed the GDPR module and saw that "Delete my account" and "Download my account data" were not translated (using `fr_FR`). I was able to enable the translation by adding `translate="label"`.