### PR TITLE
Use Magento password validation

### DIFF
--- a/app/code/community/PH2M/Gdpr/controllers/CustomerController.php
+++ b/app/code/community/PH2M/Gdpr/controllers/CustomerController.php
@@ -92,13 +92,8 @@ class PH2M_Gdpr_CustomerController extends Mage_Core_Controller_Front_Action
         }
         if (Mage::getStoreConfig('phgdpr/customer_data_remove/enable_password_confirmation_for_delete')) {
             $passwordConfirmation   = $this->getRequest()->getParam('password');
-            $hash                   = $customer->getPasswordHash();
-            $hashPassword           = explode(':', $hash);
-            $firstPart              = $hashPassword[0];
-            $salt                   = $hashPassword[1];
-            $current_password       = md5($salt . $passwordConfirmation);
 
-            if ($current_password != $firstPart) {
+            if (!$customer->validatePassword($passwordConfirmation)) {
                 Mage::getSingleton('core/session')->addError(Mage::helper('phgdpr')->__('Invalid password'));
                 return $this->_redirectReferer();
             }


### PR DESCRIPTION
Magento installation can now use sha256/512. Using Magento own [validatePassword](https://github.com/OpenMage/magento-lts/blob/cd985b89e8cb5b2665748c9c6f05f2c333502e0e/app/code/core/Mage/Customer/Model/Customer.php#L538) is more reliable. 

See here : https://github.com/OpenMage/magento-lts/blob/cd985b89e8cb5b2665748c9c6f05f2c333502e0e/app/code/core/Mage/Core/Model/Encryption.php#L112